### PR TITLE
Implement basic functionality

### DIFF
--- a/.devcontainer/.dev_config.yaml
+++ b/.devcontainer/.dev_config.yaml
@@ -1,3 +1,4 @@
 # Please only mention the non-default settings here:
 
 host: 0.0.0.0
+service_url: http://localhost:8080

--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ top --help
 ### Parameters
 
 The service requires the following configuration parameters:
+- **`issuer`** *(string)*: test issuer URL. Default: `https://test-op.org`.
+
+- **`user_domain`** *(string)*: domain name of the home organization of the test users. Default: `home.org`.
+
+- **`client_id`** *(string)*: test client ID. Default: `test-client`.
+
+- **`valid_seconds`** *(integer)*: default expiration time of access tokens in seconds. Default: `3600`.
+
 - **`host`** *(string)*: IP of the host. Default: `127.0.0.1`.
 
 - **`port`** *(integer)*: Port to expose the server on the specified host. Default: `8080`.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ The service requires the following configuration parameters:
 
   - **Items** *(string)*
 
-- **`service_name`** *(string)*: Default: `top`.
+- **`service_name`** *(string)*: Short name of this service. Default: `top`.
+
+- **`service_url`** *(string)*: External base URL of this service. Default: `https://top`.
 
 
 ### Usage:

--- a/config_schema.json
+++ b/config_schema.json
@@ -178,10 +178,23 @@
     },
     "service_name": {
       "title": "Service Name",
+      "description": "Short name of this service",
       "default": "top",
       "env_names": [
         "top_service_name"
       ],
+      "type": "string"
+    },
+    "service_url": {
+      "title": "Service Url",
+      "description": "External base URL of this service",
+      "default": "https://top",
+      "env_names": [
+        "top_service_url"
+      ],
+      "minLength": 1,
+      "maxLength": 65536,
+      "format": "uri",
       "type": "string"
     }
   },

--- a/config_schema.json
+++ b/config_schema.json
@@ -3,6 +3,46 @@
   "description": "Modifies the orginal Settings class provided by the user",
   "type": "object",
   "properties": {
+    "issuer": {
+      "title": "Issuer",
+      "description": "test issuer URL",
+      "default": "https://test-op.org",
+      "env_names": [
+        "top_issuer"
+      ],
+      "minLength": 1,
+      "maxLength": 65536,
+      "format": "uri",
+      "type": "string"
+    },
+    "user_domain": {
+      "title": "User Domain",
+      "description": "domain name of the home organization of the test users",
+      "default": "home.org",
+      "env_names": [
+        "top_user_domain"
+      ],
+      "type": "string"
+    },
+    "client_id": {
+      "title": "Client Id",
+      "description": "test client ID",
+      "default": "test-client",
+      "env_names": [
+        "top_client_id"
+      ],
+      "type": "string"
+    },
+    "valid_seconds": {
+      "title": "Valid Seconds",
+      "description": "default expiration time of access tokens in seconds",
+      "default": 3600,
+      "env_names": [
+        "top_valid_seconds"
+      ],
+      "exclusiveMinimum": 0,
+      "type": "integer"
+    },
     "host": {
       "title": "Host",
       "description": "IP of the host.",

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -1,13 +1,17 @@
 api_root_path: /
 auto_reload: false
+client_id: test-client
 cors_allow_credentials: null
 cors_allowed_headers: null
 cors_allowed_methods: null
 cors_allowed_origins: null
 docs_url: /docs
 host: 0.0.0.0
+issuer: https://test-op.org
 log_level: info
 openapi_url: /openapi.json
 port: 8080
 service_name: top
+user_domain: home.org
+valid_seconds: 3600
 workers: 1

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -12,6 +12,7 @@ log_level: info
 openapi_url: /openapi.json
 port: 8080
 service_name: top
+service_url: http://localhost:8080
 user_domain: home.org
 valid_seconds: 3600
 workers: 1

--- a/example_data/README.md
+++ b/example_data/README.md
@@ -1,0 +1,4 @@
+# Example Data
+This folder is may contain data (e.g. as json files) that can be used
+during development or testing, to set the application to an initial
+state, e.g. by populating the applications database with (realistic) data.

--- a/example_data/README.md
+++ b/example_data/README.md
@@ -1,4 +1,0 @@
-# Example Data
-This folder is may contain data (e.g. as json files) that can be used
-during development or testing, to set the application to an initial
-state, e.g. by populating the applications database with (realistic) data.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,16 +1,117 @@
+components:
+  schemas:
+    LoginInfo:
+      description: Data that is used to login as a user.
+      properties:
+        email:
+          description: e-mail address of the user
+          format: email
+          title: Email
+          type: string
+        name:
+          description: the full name of the user
+          title: Name
+          type: string
+        sub:
+          description: subject identifier
+          title: Sub
+          type: string
+        valid_seconds:
+          anyOf:
+          - exclusiveMinimum: 0.0
+            type: integer
+          - exclusiveMinimum: 0.0
+            type: number
+          description: seconds until the login expires
+          title: Valid Seconds
+      required:
+      - name
+      title: LoginInfo
+      type: object
+    UserInfo:
+      description: Data that is returned by the UserInfo endpoint.
+      properties:
+        email:
+          description: e-mail address of the user
+          format: email
+          title: Email
+          type: string
+        name:
+          description: the full name of the user
+          title: Name
+          type: string
+        sub:
+          description: subject identifier
+          title: Sub
+          type: string
+      required:
+      - sub
+      - email
+      - name
+      title: UserInfo
+      type: object
+  securitySchemes:
+    HTTPBearer:
+      scheme: bearer
+      type: http
 info:
   title: FastAPI
   version: 0.1.0
 openapi: 3.0.2
 paths:
-  /:
+  /health:
     get:
-      description: Greet the World
-      operationId: index__get
+      description: Used to test if this service is alive
+      operationId: health_health_get
       responses:
         '200':
           content:
             application/json:
               schema: {}
           description: Successful Response
-      summary: Greet the world
+      summary: health
+      tags:
+      - TestOP
+  /login:
+    post:
+      description: The UserInfo endpoint of the test OP.
+      operationId: login_login_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginInfo'
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                title: Response 201 Login Login Post
+                type: string
+          description: Access token has been created.
+        '422':
+          description: Validation error in submitted data.
+      summary: Log in as a test user
+      tags:
+      - TestOP
+  /userinfo:
+    get:
+      description: The UserInfo endpoint of the test OP.
+      operationId: get_userinfo_userinfo_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserInfo'
+          description: User info has been fetched.
+        '403':
+          description: Not authorized to get user info.
+        '422':
+          description: Validation error in submitted data.
+      security:
+      - HTTPBearer: []
+      summary: Get user information
+      tags:
+      - TestOP

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -28,6 +28,79 @@ components:
       - name
       title: LoginInfo
       type: object
+    OidcConfiguration:
+      description: Data that is returned as OpenID Connect configuration.
+      properties:
+        claims_supported:
+          default:
+          - sub
+          - name
+          - email
+          description: List of the Claims that the OP can supply values for
+          items:
+            type: string
+          title: Claims Supported
+          type: array
+        issuer:
+          default: https://test-op.org
+          description: URL that the OP asserts as its Issuer Identifier
+          format: uri
+          maxLength: 65536
+          minLength: 1
+          title: Issuer
+          type: string
+        request_object_signing_alg_values_supported:
+          default:
+          - ES512
+          description: List of JWS signing algorithms supported by the OP for Request
+            Objects
+          items:
+            type: string
+          title: Request Object Signing Alg Values Supported
+          type: array
+        scopes_supported:
+          default:
+          - openid
+          - profile
+          - email
+          description: List of the OAuth 2.0 scope values that this server supports
+          items:
+            type: string
+          title: Scopes Supported
+          type: array
+        service_documentation:
+          default: https://github.com/ghga-de/test-oidc-provider
+          description: URL of a page with information that developers might need to
+            know when using the OP
+          format: uri
+          maxLength: 65536
+          minLength: 1
+          title: Service Documentation
+          type: string
+        userinfo_endpoint:
+          default: http://localhost:8080/useinfo
+          description: URL of the OP's UserInfo Endpoint
+          format: uri
+          maxLength: 65536
+          minLength: 1
+          title: Userinfo Endpoint
+          type: string
+        userinfo_signing_alg_values_supported:
+          default:
+          - ES512
+          description: List of JWS signing algorithms supported by the OP for the
+            UserInfo endpoint
+          items:
+            type: string
+          title: Userinfo Signing Alg Values Supported
+          type: array
+        version:
+          default: 0.1.0
+          description: Version of the test OpenID Connect Provider
+          title: Version
+          type: string
+      title: OidcConfiguration
+      type: object
     UserInfo:
       description: Data that is returned by the UserInfo endpoint.
       properties:
@@ -59,6 +132,20 @@ info:
   version: 0.1.0
 openapi: 3.0.2
 paths:
+  /.well-known/openid-configuration:
+    get:
+      description: The OpenID discovery endpoint.
+      operationId: get_openid_configuration__well_known_openid_configuration_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OidcConfiguration'
+          description: Successful Response
+      summary: Get the OpenID connect configuration
+      tags:
+      - TestOP
   /health:
     get:
       description: Used to test if this service is alive
@@ -74,7 +161,7 @@ paths:
       - TestOP
   /login:
     post:
-      description: The UserInfo endpoint of the test OP.
+      description: Endpoint for logging in to the OP as a test user.
       operationId: login_login_post
       requestBody:
         content:

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,8 +36,8 @@ include_package_data = True
 packages = find:
 install_requires =
     typer==0.7.0
-    ghga-service-commons[api]==0.3.1
-    hexkit[akafka,s3,mongodb]==0.9.2
+    ghga-service-commons[api,auth]==0.7.0
+    hexkit==0.10.2
 
 python_requires = >= 3.9
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -21,6 +21,7 @@ from ghga_service_commons.api.testing import AsyncTestClient
 from pytest import mark
 from pytest_asyncio import fixture as async_fixture
 
+from top import __version__
 from top.api.main import app, oidc_provider
 
 
@@ -45,6 +46,26 @@ async def test_health_check(client: AsyncTestClient):
 
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == {"status": "OK"}
+
+
+@mark.asyncio
+async def test_openid_configuration(client: AsyncTestClient):
+    """Test getting the OpenID configuration from the well-known path."""
+
+    response = await client.get("/.well-known/openid-configuration")
+
+    openid_config = response.json()
+    print(openid_config)
+    assert openid_config == {
+        "version": __version__,
+        "issuer": "https://test-op.org",
+        "scopes_supported": ["openid", "profile", "email"],
+        "claims_supported": ["sub", "name", "email"],
+        "request_object_signing_alg_values_supported": ["ES512"],
+        "userinfo_signing_alg_values_supported": ["ES512"],
+        "userinfo_endpoint": "http://localhost:8080//userinfo",
+        "service_documentation": "https://github.com/ghga-de/test-oidc-provider",
+    }
 
 
 @mark.asyncio

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,97 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from typing import AsyncGenerator
+
+from fastapi import status
+from ghga_service_commons.api.testing import AsyncTestClient
+from pytest import mark
+from pytest_asyncio import fixture as async_fixture
+
+from top.api.main import app, oidc_provider
+
+
+@async_fixture(name="client")
+async def fixture_client() -> AsyncGenerator[AsyncTestClient, None]:
+    """Get test client for this application."""
+
+    async with AsyncTestClient(app=app) as client:
+        yield client
+
+
+def headers_for_token(token: str) -> dict[str, str]:
+    """Get the Authorization headers for the given token."""
+    return {"Authorization": f"Bearer {token}"}
+
+
+@mark.asyncio
+async def test_health_check(client: AsyncTestClient):
+    """Test that the health check endpoint works."""
+
+    response = await client.get("/health")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"status": "OK"}
+
+
+@mark.asyncio
+async def test_get_user_info_without_login(client: AsyncTestClient):
+    """Test getting user info without first logging in."""
+
+    response = await client.get("/userinfo")
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    response = await client.get("/userinfo", headers=headers_for_token("foo.bar.baz"))
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@mark.asyncio
+async def test_login_and_get_user_info(client: AsyncTestClient):
+    """Test logging in as a user and getting the user info back."""
+
+    response = await client.post("/login", json={"name": "John Doe"})
+    assert response.status_code == status.HTTP_201_CREATED
+
+    token = response.text
+    assert token and token.isascii() and token.count(".") == 2
+    claims = oidc_provider.decode_and_validate_token(token)
+    iat, exp = claims.pop("iat"), claims.pop("exp")
+    assert isinstance(iat, int)
+    assert isinstance(exp, int)
+    assert exp - iat == 60 * 60
+    assert claims == {
+        "aud": ["test-client"],
+        "client_id": "test-client",
+        "iss": "https://test-op.org",
+        "jti": "test-1",
+        "scope": "openid profile email",
+        "sid": "test-1",
+        "sub": "id-of-john-doe@test-op.org",
+        "token_class": "access_token",
+    }
+
+    response = await client.get("/userinfo")
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    response = await client.get("/userinfo", headers=headers_for_token(token))
+    assert response.status_code == status.HTTP_200_OK
+
+    user_info = response.json()
+    assert user_info == {
+        "email": "john.doe@home.org",
+        "name": "John Doe",
+        "sub": "id-of-john-doe@test-op.org",
+    }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -272,7 +272,7 @@ async def test_more_expiring_tasks():
     provider = OidcProvider(config)
 
     def create_token(name: str, short=False) -> str:
-        valid_seconds = 0.1 if short else None  # type: ignore
+        valid_seconds = 0.1 if short else None
         login = LoginInfo(name=name, valid_seconds=valid_seconds)  # pyright: ignore
         return provider.login(login)
 

--- a/tests/test_oidc_provider.py
+++ b/tests/test_oidc_provider.py
@@ -1,0 +1,287 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Unit tests for the core functionality."""
+
+import asyncio
+
+from ghga_service_commons.utils.utc_dates import now_as_utc
+from pytest import mark, raises
+
+from top.core.models import UserInfo
+from top.core.oidc_provider import OidcProvider, OidcProviderConfig
+
+
+def test_create_default_op():
+    """Create a default test OP."""
+    config = OidcProviderConfig()  # pyright: ignore
+    provider = OidcProvider(config)
+    assert provider.issuer == "https://test-op.org"
+    assert provider.op_domain == "test-op.org"
+    assert provider.user_domain == "home.org"
+    assert provider.client_id == "test-client"
+    assert provider.valid_seconds == 60 * 60
+    assert not provider.users
+    assert provider.next_jti == "test-1"
+
+
+def test_create_custom_op():
+    """Create a custom test OP."""
+    config = OidcProviderConfig(
+        issuer="https://proxy.aai.lifescience-ri.eu",  # pyright: ignore
+        user_domain="dkfz.de",
+        client_id="GHGA-Client",
+        valid_seconds=90 * 60,
+    )
+    provider = OidcProvider(config)
+    assert provider.issuer == "https://proxy.aai.lifescience-ri.eu"
+    assert provider.op_domain == "lifescience-ri.eu"
+    assert provider.user_domain == "dkfz.de"
+    assert provider.client_id == "GHGA-Client"
+    assert provider.valid_seconds == 90 * 60
+    assert not provider.users
+    assert provider.next_jti == "test-1"
+
+
+def test_invalid_token():
+    """Try to get a user with an invalid token."""
+    config = OidcProviderConfig()  # pyright: ignore
+    provider = OidcProvider(config)
+    with raises(KeyError):
+        provider.get_user_info("bad")
+
+
+@mark.asyncio
+async def test_user_info_for_default_token():
+    """Create a default access token for a dummy user."""
+    config = OidcProviderConfig()  # pyright: ignore
+    provider = OidcProvider(config)
+
+    token = provider.create_access_token("John Doe")
+    assert isinstance(token, str)
+    assert len(provider.users) == 1
+    user = provider.get_user_info(token)
+    assert user.name == "John Doe"
+    assert user.email == "john.doe@home.org"
+    assert user.sub == "id-of-john-doe@test-op.org"
+
+    assert len(provider.tasks) == 1
+    await provider.reset()
+    assert not provider.users
+    assert not provider.tasks
+
+    with raises(KeyError):
+        provider.get_user_info(token)
+
+
+@mark.asyncio
+async def test_user_info_for_custom_token():
+    """Create a custom access token for a dummy user."""
+    config = OidcProviderConfig()  # pyright: ignore
+    provider = OidcProvider(config)
+
+    token = provider.create_access_token(
+        "Dr. Jane Roe", email="jane@foo.edu", sub="sub-of-jane"
+    )
+    assert isinstance(token, str)
+    assert len(provider.users) == 1
+    user = provider.get_user_info(token)
+    assert isinstance(user, UserInfo)
+    assert user.name == "Dr. Jane Roe"
+    assert user.email == "jane@foo.edu"
+    assert user.sub == "sub-of-jane"
+
+    assert len(provider.tasks) == 1
+    await provider.reset()
+    assert not provider.users
+    assert not provider.tasks
+
+    with raises(KeyError):
+        provider.get_user_info(token)
+
+
+@mark.asyncio
+async def test_user_info_for_default_token_of_custom_op():
+    """Create a custom access token for a dummy user."""
+    config = OidcProviderConfig(
+        issuer="https://proxy.aai.lifescience-ri.eu",  # pyright: ignore
+        user_domain="dkfz.de",
+        client_id="GHGA-Client",
+        valid_seconds=90 * 60,
+    )
+    provider = OidcProvider(config)
+
+    token = provider.create_access_token("Frank Foo")
+    assert isinstance(token, str)
+    assert len(provider.users) == 1
+    user = provider.get_user_info(token)
+    assert isinstance(user, UserInfo)
+    assert user.name == "Frank Foo"
+    assert user.email == "frank.foo@dkfz.de"
+    assert user.sub == "id-of-frank-foo@lifescience-ri.eu"
+
+    assert len(provider.tasks) == 1
+    await provider.reset()
+    assert not provider.users
+    assert not provider.tasks
+
+
+@mark.asyncio
+async def test_user_infos_for_two_default_tokens():
+    """Create two default access tokens for two dummy users."""
+    config = OidcProviderConfig()  # pyright: ignore
+    provider = OidcProvider(config)
+
+    token1 = provider.create_access_token("John Doe")
+    token2 = provider.create_access_token("Dr. Jane Roe")
+    assert token1 != token2
+    assert len(provider.users) == 2
+    user1 = provider.get_user_info(token1)
+    assert user1.name == "John Doe"
+    user2 = provider.get_user_info(token2)
+    assert user2.name == "Dr. Jane Roe"
+    assert provider.next_jti == "test-3"
+
+    assert len(provider.tasks) == 2
+    await provider.reset()
+    assert not provider.users
+    assert not provider.tasks
+
+
+@mark.asyncio
+async def test_validate_default_tokens():
+    """Create two access tokens and validate them."""
+    config = OidcProviderConfig()  # pyright: ignore
+    provider = OidcProvider(config)
+
+    token = provider.create_access_token("John Doe")
+    claims = provider.decode_and_validate_token(token)
+    assert isinstance(claims, dict)
+    keys = " ".join(sorted(claims))
+    assert keys == "aud client_id exp iat iss jti scope sid sub token_class"
+    assert claims["client_id"] == "test-client"
+    assert claims["aud"] == [claims["client_id"]]
+    assert claims["iss"] == "https://test-op.org"
+    assert claims["jti"] == "test-1"
+    assert claims["sid"] == claims["jti"]
+    assert claims["scope"] == "openid profile email"
+    assert claims["sub"] == "id-of-john-doe@test-op.org"
+    assert claims["token_class"] == "access_token"
+    iat = claims["iat"]
+    assert isinstance(iat, int)
+    exp = claims["exp"]
+    assert isinstance(exp, int)
+    assert exp - iat == 60 * 60
+    now = now_as_utc().timestamp()
+    assert 0 <= now - iat < 5
+
+    token = provider.create_access_token(
+        "Dr. Jane Roe", email="jane@foo.edu", sub="sub-of-jane", valid_seconds=30
+    )
+    claims = provider.decode_and_validate_token(token)
+    assert isinstance(claims, dict)
+    keys = " ".join(sorted(claims))
+    assert keys == "aud client_id exp iat iss jti scope sid sub token_class"
+    assert claims["client_id"] == "test-client"
+    assert claims["aud"] == [claims["client_id"]]
+    assert claims["iss"] == "https://test-op.org"
+    assert claims["jti"] == "test-2"
+    assert claims["sid"] == claims["jti"]
+    assert claims["scope"] == "openid profile email"
+    assert claims["sub"] == "sub-of-jane"
+    assert claims["token_class"] == "access_token"
+    iat = claims["iat"]
+    assert isinstance(iat, int)
+    exp = claims["exp"]
+    assert isinstance(exp, int)
+    assert exp - iat == 30
+    now = now_as_utc().timestamp()
+    assert 0 <= now - iat < 5
+
+    assert len(provider.tasks) == 2
+    await provider.reset()
+    assert not provider.users
+    assert not provider.tasks
+
+
+@mark.asyncio
+async def test_expiration():
+    """Check that tokens expire after the specified time."""
+    config = OidcProviderConfig()  # pyright: ignore
+    provider = OidcProvider(config)
+
+    token1 = provider.create_access_token("Long John Silver")
+
+    user1 = provider.get_user_info(token1)
+    assert user1.name == "Long John Silver"
+
+    token2 = provider.create_access_token(
+        "Short John Silver", valid_seconds=0.1  # type: ignore
+    )
+
+    user2 = provider.get_user_info(token2)
+    assert user2.name == "Short John Silver"
+
+    await asyncio.sleep(0.15)
+
+    user1 = provider.get_user_info(token1)
+    assert user1.name == "Long John Silver"
+
+    with raises(KeyError):
+        provider.get_user_info(token2)
+
+    assert len(provider.tasks) == 1
+    await provider.reset()
+    assert not provider.users
+    assert not provider.tasks
+
+    with raises(KeyError):
+        provider.get_user_info(token1)
+
+
+@mark.asyncio
+async def test_more_expiring_tasks():
+    """Check that multiple tokens expire after the specified time."""
+    config = OidcProviderConfig()  # pyright: ignore
+    provider = OidcProvider(config)
+
+    create_token = provider.create_access_token
+
+    tokens = [
+        (
+            create_token(f"Long John Silver {i}"),
+            create_token(f"Short John Silver {i}", valid_seconds=0.1),  # type: ignore
+        )
+        for i in range(10)
+    ]
+
+    await asyncio.sleep(0.15)
+
+    for long_token, short_tokens in tokens:
+        assert provider.get_user_info(long_token).name.startswith("Long")
+        with raises(KeyError):
+            provider.get_user_info(short_tokens)
+
+    assert len(provider.tasks) == 10
+    await provider.reset()
+    assert not provider.users
+    assert not provider.tasks
+
+    for long_token, short_tokens in tokens:
+        with raises(KeyError):
+            assert provider.get_user_info(long_token)
+        with raises(KeyError):
+            provider.get_user_info(short_tokens)

--- a/top/api/main.py
+++ b/top/api/main.py
@@ -15,6 +15,9 @@
 
 """Module containing the main FastAPI router and API endpoints."""
 
+from enum import Enum
+from typing import Union
+
 from fastapi import FastAPI, HTTPException, Response, Security, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from ghga_service_commons.api import configure_app
@@ -28,7 +31,7 @@ configure_app(app, config=CONFIG)
 
 oidc_provider = OidcProvider(CONFIG)
 
-tags = ["TestOP"]
+tags: list[Union[str, Enum]] = ["TestOP"]
 
 
 @app.get(

--- a/top/config.py
+++ b/top/config.py
@@ -18,9 +18,11 @@
 from ghga_service_commons.api import ApiConfigBase
 from hexkit.config import config_from_yaml
 
+from top.core.oidc_provider import OidcProviderConfig
+
 
 @config_from_yaml(prefix="top")
-class Config(ApiConfigBase):
+class Config(ApiConfigBase, OidcProviderConfig):
     """Config parameters and their defaults."""
 
     service_name: str = "top"

--- a/top/config.py
+++ b/top/config.py
@@ -17,15 +17,22 @@
 
 from ghga_service_commons.api import ApiConfigBase
 from hexkit.config import config_from_yaml
+from pydantic import AnyHttpUrl, Field
 
 from top.core.oidc_provider import OidcProviderConfig
 
+SERVICE_NAME = "top"
 
-@config_from_yaml(prefix="top")
+
+@config_from_yaml(prefix=SERVICE_NAME)
 class Config(ApiConfigBase, OidcProviderConfig):
     """Config parameters and their defaults."""
 
-    service_name: str = "top"
+    service_name: str = Field(SERVICE_NAME, description="Short name of this service")
+    service_url: AnyHttpUrl = Field(
+        "https://" + SERVICE_NAME,  # pyright: ignore
+        description="External base URL of this service",
+    )
 
 
-CONFIG = Config()
+CONFIG = Config()  # pyright: ignore

--- a/top/core/__init__.py
+++ b/top/core/__init__.py
@@ -13,7 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-This sub-package contains the main business functionality of this service.
-It should not contain any service API-related code.
-"""
+"""Core functionality of the test OIDC provider."""

--- a/top/core/models.py
+++ b/top/core/models.py
@@ -18,9 +18,11 @@
 
 from typing import Optional, Union
 
-from pydantic import BaseModel, EmailStr, Field, PositiveFloat, PositiveInt
+from pydantic import AnyHttpUrl, BaseModel, EmailStr, Field, PositiveFloat, PositiveInt
 
-__all__ = ["LoginInfo", "UserInfo"]
+from .. import __version__
+
+__all__ = ["LoginInfo", "UserInfo", "OidcConfiguration"]
 
 
 class LoginInfo(BaseModel):
@@ -40,3 +42,41 @@ class UserInfo(BaseModel):
     sub: str = Field(..., description="subject identifier")
     email: EmailStr = Field(..., description="e-mail address of the user")
     name: str = Field(..., description="the full name of the user")
+
+
+class OidcConfiguration(BaseModel):
+    """Data that is returned as OpenID Connect configuration."""
+
+    version: str = Field(
+        __version__, description="Version of the test OpenID Connect Provider"
+    )
+    issuer: AnyHttpUrl = Field(
+        "https://test-op.org",
+        description="URL that the OP asserts as its Issuer Identifier",
+    )
+    scopes_supported: list[str] = Field(
+        ["openid", "profile", "email"],
+        description="List of the OAuth 2.0 scope values that this server supports",
+    )
+    claims_supported: list[str] = Field(
+        ["sub", "name", "email"],
+        description="List of the Claims that the OP can supply values for",
+    )
+    request_object_signing_alg_values_supported: list[str] = Field(
+        ["ES512"],
+        description="List of JWS signing algorithms"
+        " supported by the OP for Request Objects",
+    )
+    userinfo_signing_alg_values_supported: list[str] = Field(
+        ["ES512"],
+        description="List of JWS signing algorithms"
+        " supported by the OP for the UserInfo endpoint",
+    )
+    userinfo_endpoint: AnyHttpUrl = Field(
+        "http://localhost:8080/useinfo", description="URL of the OP's UserInfo Endpoint"
+    )
+    service_documentation: AnyHttpUrl = Field(
+        "https://github.com/ghga-de/test-oidc-provider",
+        description="URL of a page with information"
+        " that developers might need to know when using the OP",
+    )

--- a/top/core/models.py
+++ b/top/core/models.py
@@ -12,10 +12,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
 
-"""Test dummy."""
+"""Models used by the API"""
+
+from pydantic import BaseModel, Field
+
+__all__ = ["UserInfo"]
 
 
-def test_dummy():
-    """Just makes the CI pass."""
-    assert True
+class UserInfo(BaseModel):
+    """Data that is returned by the UserInfo endpoint."""
+
+    sub: str = Field(..., description="subject identifier")
+    email: str = Field(..., description="e-mail address of the user")
+    name: str = Field(..., description="the full name of the user")

--- a/top/core/models.py
+++ b/top/core/models.py
@@ -16,14 +16,27 @@
 
 """Models used by the API"""
 
-from pydantic import BaseModel, Field
+from typing import Optional, Union
 
-__all__ = ["UserInfo"]
+from pydantic import BaseModel, EmailStr, Field, PositiveFloat, PositiveInt
+
+__all__ = ["LoginInfo", "UserInfo"]
+
+
+class LoginInfo(BaseModel):
+    """Data that is used to login as a user."""
+
+    sub: Optional[str] = Field(None, description="subject identifier")
+    email: Optional[EmailStr] = Field(None, description="e-mail address of the user")
+    name: str = Field(..., description="the full name of the user")
+    valid_seconds: Optional[Union[PositiveInt, PositiveFloat]] = Field(
+        None, description="seconds until the login expires"
+    )
 
 
 class UserInfo(BaseModel):
     """Data that is returned by the UserInfo endpoint."""
 
     sub: str = Field(..., description="subject identifier")
-    email: str = Field(..., description="e-mail address of the user")
+    email: EmailStr = Field(..., description="e-mail address of the user")
     name: str = Field(..., description="the full name of the user")

--- a/top/core/oidc_provider.py
+++ b/top/core/oidc_provider.py
@@ -1,0 +1,193 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Test OpenID Connect provider"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from ghga_service_commons.utils.jwt_helpers import (
+    decode_and_validate_token,
+    generate_jwk,
+    sign_and_serialize_token,
+)
+from jwcrypto import jwk
+from pydantic import AnyHttpUrl, BaseSettings, Field
+
+from .models import UserInfo
+
+__all__ = ["OidcProviderConfig", "OidcProvider"]
+
+
+class OidcProviderConfig(BaseSettings):
+    """The configuration for a test OpenID Connect provider."""
+
+    issuer: AnyHttpUrl = Field("https://test-op.org", description="test issuer URL")
+    user_domain: str = Field(
+        "home.org", description="domain name of the home organization of the test users"
+    )
+    client_id: str = Field("test-client", description="test client ID")
+    valid_seconds: int = Field(
+        60 * 60, description="default expiration time of access tokens in seconds"
+    )
+
+
+class OidcProvider:  # pylint: disable=too-many-instance-attributes
+    """A test OpenID Connect provider."""
+
+    users: dict[str, UserInfo]
+    key_set: jwk.JWKSet
+    issuer: str
+    op_domain: str
+    user_domain: str
+    client_id: str
+    serial_id: int
+    tasks: set[asyncio.Task]
+
+    def __init__(self, config: OidcProviderConfig) -> None:
+        """Initialize the OP."""
+        issuer = config.issuer
+        self.issuer = issuer
+        if not issuer or "://" not in issuer or "." not in issuer:
+            raise ValueError(f"Invalid issuer: {issuer!r}")
+        user_domain = config.user_domain
+        if not user_domain or "://" in user_domain or "." not in user_domain:
+            raise ValueError(f"Invalid user domain: {user_domain!r}")
+        self.op_domain = ".".join(
+            issuer.split("://", 1)[-1].split("/", 1)[0].rsplit(".", 2)[-2:]
+        )
+        self.valid_seconds = config.valid_seconds
+        self.user_domain = user_domain
+        self.client_id = config.client_id
+        self.generate_keys()
+        self.users = {}
+        self.serial_id = 1
+        self.tasks = set()
+
+    async def cancel_tasks(self):
+        """Cleanup all pending tasks."""
+        tasks = self.tasks
+        while tasks:
+            task = tasks.pop()
+            if not task.done():
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+
+    async def reset(self):
+        """Reset the OP, clear all data."""
+        await self.cancel_tasks()
+        self.users.clear()
+        self.serial_id = 1
+
+    def add_user(self, token: str, user: UserInfo) -> None:
+        """Add the given user to the cache."""
+        self.users[token] = user
+        self.serial_id += 1
+
+    def generate_keys(self) -> None:
+        """Generate a key set with a key pair for signing the tokens."""
+        key = generate_jwk()  # generates EC keys
+        key["kid"] = "test"
+        key_set = jwk.JWKSet()
+        key_set.add(key)
+        self.key_set = key_set
+
+    @property
+    def key(self) -> jwk.JWK:
+        """Get the single key pair from the key set."""
+        key = self.key_set.get_key("test")
+        if key is None:
+            raise KeyError("Cannot retrieve the signing key.")
+        return key
+
+    @property
+    def next_jti(self):
+        """Determine the next jti value."""
+        return f"test-{len(self.users) + 1}"
+
+    def add_cleanup_task(self, token: str, valid_seconds: int) -> None:
+        """Add a task to remove the token in the cache after the given time."""
+
+        async def cleanup_task(token: str, valid_seconds: int) -> None:
+            """Remove the given token in the cache after the given time."""
+            await asyncio.sleep(valid_seconds)
+            if token in self.users:
+                del self.users[token]
+            self.tasks.remove(task)
+
+        task = asyncio.create_task(cleanup_task(token, valid_seconds))
+        self.tasks.add(task)
+
+    def create_access_token(
+        self,
+        name: str,
+        email: str | None = None,
+        sub: str | None = None,
+        valid_seconds: int | None = None,
+    ) -> str:
+        """Create and cache an access token for a given user.
+
+        If no subject identifier is passed, it is derived from the user name.
+        """
+        if not name:
+            raise ValueError("The name of the user must be specified.")
+        if valid_seconds is None:
+            valid_seconds = self.valid_seconds
+        if not valid_seconds or valid_seconds < 0:
+            raise ValueError("The expiration time is invalid.")
+        if email:
+            if "@" not in email:
+                raise ValueError("The email address of the user is invalid.")
+        else:
+            email = name.lower().replace(" ", ".") + f"@{self.user_domain}"
+        if not sub:
+            user_id = "id-of-" + name.lower().replace(" ", "-")
+            sub = f"{user_id}@{self.op_domain}"
+        user = UserInfo(sub=sub, email=email, name=name)
+        jti = f"test-{self.serial_id}"
+        claims = {
+            "jti": jti,
+            "sid": jti,
+            "iss": self.issuer,
+            "sub": sub,
+            "client_id": self.client_id,
+            "token_class": "access_token",
+            "scope": "openid profile email",
+            "aud": [self.client_id],
+        }
+        token = sign_and_serialize_token(
+            claims, key=self.key, valid_seconds=valid_seconds
+        )
+        self.add_user(token, user)
+        self.add_cleanup_task(token, valid_seconds)
+        return token
+
+    def get_user_info(self, token: str) -> UserInfo:
+        """Return the user info associated with the given access token.
+
+        Raises a KeyError if no user info is associated with the given token.
+        This means the token is invalid in the context of this OP provider.
+        """
+        return self.users[token]
+
+    def decode_and_validate_token(self, token: str) -> dict[str, Any]:
+        """Decode and validate the given token."""
+        return decode_and_validate_token(token, self.key)

--- a/top/core/oidc_provider.py
+++ b/top/core/oidc_provider.py
@@ -140,7 +140,7 @@ class OidcProvider:  # pylint: disable=too-many-instance-attributes
         valid_seconds = login_info.valid_seconds
         if valid_seconds is None:
             valid_seconds = self.valid_seconds
-        email = login_info.email
+        email = str(login_info.email)
         if email is None:
             email = (
                 name.lower().replace(" ", ".").replace("..", ".")

--- a/top/core/oidc_provider.py
+++ b/top/core/oidc_provider.py
@@ -140,12 +140,13 @@ class OidcProvider:  # pylint: disable=too-many-instance-attributes
         valid_seconds = login_info.valid_seconds
         if valid_seconds is None:
             valid_seconds = self.valid_seconds
-        email = str(login_info.email)
-        if email is None:
+        if login_info.email is None:
             email = (
                 name.lower().replace(" ", ".").replace("..", ".")
                 + f"@{self.user_domain}"
             )
+        else:
+            email = str(login_info.email)
         sub = login_info.sub
         if not sub:
             user_id = "id-of-" + name.lower().replace(" ", "-")


### PR DESCRIPTION
This PR implements the basic functionality that we need for the inter service integration tests:

- Creating access tokens for arbitrary test users (login endpoint)
- Providing a UserInfo endpoint (for the auth adapter)