### PR TITLE
Improve root path detection

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "top"
-version = "1.2.0"
+version = "1.2.1"
 description = "Test OpenID Connect provider"
 dependencies = [
     "typer >= 0.12",

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/test-oidc-provider):
 ```bash
-docker pull ghga/test-oidc-provider:1.2.0
+docker pull ghga/test-oidc-provider:1.2.1
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/test-oidc-provider:1.2.0 .
+docker build -t ghga/test-oidc-provider:1.2.1 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -32,7 +32,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/test-oidc-provider:1.2.0 --help
+docker run -p 8080:8080 ghga/test-oidc-provider:1.2.1 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -115,7 +115,7 @@ components:
           title: Userinfo Signing Alg Values Supported
           type: array
         version:
-          default: 1.2.0
+          default: 1.2.1
           description: Version of the test OpenID Connect Provider
           title: Version
           type: string

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "top"
-version = "1.2.0"
+version = "1.2.1"
 description = "Test OpenID Connect provider"
 dependencies = [
     "typer >= 0.12",

--- a/src/top/api/main.py
+++ b/src/top/api/main.py
@@ -25,6 +25,7 @@ from ghga_service_commons.api import configure_app
 from pydantic import AnyHttpUrl
 
 from ..config import CONFIG
+from ..core.http_utils import get_original_url
 from ..core.models import LoginInfo, OidcConfiguration, UserInfo
 from ..core.oidc_provider import Jwks, OidcProvider
 
@@ -57,14 +58,12 @@ async def health():
 )
 async def get_openid_configuration(request: Request) -> OidcConfiguration:
     """The OpenID discovery endpoint."""
-    print("Request headers:", request.headers)
-    # get the URL for this endpoint sans query params
-    this_url = str(request.url.replace(query=None))
+    original_url = get_original_url(request)
     # remove the current route to get the root URL
-    root_url = this_url.removesuffix(".well-known/openid-configuration")
+    base_url = original_url.removesuffix(".well-known/openid-configuration")
     # construct the other urls based on the root url
-    userinfo_endpoint = AnyHttpUrl(root_url + "userinfo")
-    jwks_uri = AnyHttpUrl(root_url + "jwks")
+    userinfo_endpoint = AnyHttpUrl(base_url + "userinfo")
+    jwks_uri = AnyHttpUrl(base_url + "jwks")
     return OidcConfiguration(
         userinfo_endpoint=userinfo_endpoint,
         issuer=CONFIG.issuer,

--- a/src/top/api/main.py
+++ b/src/top/api/main.py
@@ -57,10 +57,9 @@ async def health():
 )
 async def get_openid_configuration(request: Request) -> OidcConfiguration:
     """The OpenID discovery endpoint."""
-    # create the URL for this endpoint sans query params
-    url_parts = request.url
-    this_url = f"{url_parts.scheme}://{url_parts.netloc}{url_parts.path}"
-    # remove the current route to get the root url
+    # get the URL for this endpoint sans query params
+    this_url = str(request.url.replace(query=None))
+    # remove the current route to get the root URL
     root_url = this_url.removesuffix(".well-known/openid-configuration")
     # construct the other urls based on the root url
     userinfo_endpoint = AnyHttpUrl(root_url + "userinfo")

--- a/src/top/api/main.py
+++ b/src/top/api/main.py
@@ -59,9 +59,9 @@ async def health():
 async def get_openid_configuration(request: Request) -> OidcConfiguration:
     """The OpenID discovery endpoint."""
     original_url = get_original_url(request)
-    # remove the current route to get the root URL
+    # remove the current route to get the base URL
     base_url = original_url.removesuffix(".well-known/openid-configuration")
-    # construct the other urls based on the root url
+    # construct the other URLs from the base URL
     userinfo_endpoint = AnyHttpUrl(base_url + "userinfo")
     jwks_uri = AnyHttpUrl(base_url + "jwks")
     return OidcConfiguration(

--- a/src/top/api/main.py
+++ b/src/top/api/main.py
@@ -57,6 +57,7 @@ async def health():
 )
 async def get_openid_configuration(request: Request) -> OidcConfiguration:
     """The OpenID discovery endpoint."""
+    print("Request headers:", request.headers)
     # get the URL for this endpoint sans query params
     this_url = str(request.url.replace(query=None))
     # remove the current route to get the root URL

--- a/src/top/core/http_utils.py
+++ b/src/top/core/http_utils.py
@@ -40,7 +40,7 @@ def get_original_url(request: Request) -> str:
             or headers.get("x-envoy-original-proto")
             or request.url.scheme
         )
-        original_url = f"{original_scheme}://{original_host}/{original_path}"
+        original_url = f"{original_scheme}://{original_host}{original_path}"
     else:
         # get the URL without query param from the request
         original_url = str(request.url.replace(query=None))

--- a/src/top/core/http_utils.py
+++ b/src/top/core/http_utils.py
@@ -1,0 +1,50 @@
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""HTTP Utilities"""
+
+from fastapi import Request
+
+__all__ = ["get_original_url"]
+
+
+def get_original_url(request: Request) -> str:
+    """Get the original URL used for the request."""
+    headers = request.headers
+    print("Request headers:", headers)
+    original_path = headers.get("x-forwarded-path") or headers.get(
+        "x-envoy-original-path"
+    )
+    print("Original Path:", original_path)
+    if original_path:
+        # construct the URL from the header values
+        host = (
+            headers.get("x-forwarded-host")
+            or headers.get("x-envoy-original-host")
+            or headers.get("host")
+            or request.url.netloc
+        )
+        scheme = (
+            headers.get("x-forwarded-proto")
+            or headers.get("x-envoy-original-proto")
+            or request.url.scheme
+        )
+        original_url = f"{scheme}://{host}"
+    else:
+        # get the URL for this endpoint sans query params
+        original_url = str(request.url.replace(query=None))
+    print("Original URL:", original_url)
+    return original_url

--- a/src/top/core/http_utils.py
+++ b/src/top/core/http_utils.py
@@ -24,27 +24,24 @@ __all__ = ["get_original_url"]
 def get_original_url(request: Request) -> str:
     """Get the original URL used for the request."""
     headers = request.headers
-    print("Request headers:", headers)
     original_path = headers.get("x-forwarded-path") or headers.get(
         "x-envoy-original-path"
     )
-    print("Original Path:", original_path)
     if original_path:
-        # construct the URL from the header values
-        host = (
+        # construct the URL using header values
+        original_host = (
             headers.get("x-forwarded-host")
             or headers.get("x-envoy-original-host")
             or headers.get("host")
             or request.url.netloc
         )
-        scheme = (
+        original_scheme = (
             headers.get("x-forwarded-proto")
             or headers.get("x-envoy-original-proto")
             or request.url.scheme
         )
-        original_url = f"{scheme}://{host}"
+        original_url = f"{original_scheme}://{original_host}/{original_path}"
     else:
-        # get the URL for this endpoint sans query params
+        # get the URL without query param from the request
         original_url = str(request.url.replace(query=None))
-    print("Original URL:", original_url)
     return original_url


### PR DESCRIPTION
- Use a simpler and more robust method to remove the query params from the path.
- If the access was made from outside, use the original URL by evaluating the custom headers made for this purpose (even if this method is currently only used when accessed from inside).